### PR TITLE
329 condense toggle checkboxes in live tracking

### DIFF
--- a/src/pages/LiveTracking.jsx
+++ b/src/pages/LiveTracking.jsx
@@ -212,7 +212,17 @@ const LiveTracking = () => {
                 <Table>
                     <TableHead>
                         <TableRow>
-                            <TableCell></TableCell>
+                            <TableCell>
+                                <Checkbox
+                                    sx={{
+                                        '& .MuiSvgIcon-root': {
+                                            fontSize: 28, // Adjust the size of the checkbox icon
+                                        },
+                                    }}
+                                    defaultChecked
+                                    checked={checkAllRoutes} // Control the checkbox state 
+                                />    
+                            </TableCell>
                             <TableCell>Route ID</TableCell>
                             <TableCell>Driver</TableCell>
                             <TableCell>Vehicle ID</TableCell>

--- a/src/pages/LiveTracking.jsx
+++ b/src/pages/LiveTracking.jsx
@@ -199,7 +199,7 @@ const LiveTracking = () => {
         else if (routesData && routesData.length === 0) {
             return <NoRouteFound />;}
         else if (routesData) {
-            return (
+            return ( // AREA OF INTEREST
                 <>
                     <Box sx={{ display: 'flex', justifyContent: 'center',gap: 5, margin: 2}}>
                         <Button variant="contained" color="primary" onClick={checkAllRoutes}>

--- a/src/pages/LiveTracking.jsx
+++ b/src/pages/LiveTracking.jsx
@@ -39,6 +39,7 @@ const LiveTracking = () => {
     const [dateOptions, setDateOptions] = useState([]);
 
     const [selectedDate, setSelectedDate] = useState(dayjs());
+    const [selectAll, setSelectAll] = useState(true)
 
     const colourPalette = [
 
@@ -51,6 +52,17 @@ const LiveTracking = () => {
 
     const handleDateChange = (date) => { // logic for showing orders from a specific date is still yet to be implemented.
         setSelectedDate(date);
+    };
+
+    // Responsible for check all routes
+    const handleSelectAllChange = (event) => {
+        const checked = event.target.checked;
+        const newCheckedRoutes = {};
+        routesData.forEach(route => {
+            newCheckedRoutes[route.deliveryRouteID] = checked; // Set to checked or unchecked based on the state
+        });
+        setCheckedRoutes(newCheckedRoutes);
+        setSelectAll(checked); // Update the selectAll state
     };
 
     /**
@@ -199,16 +211,8 @@ const LiveTracking = () => {
         else if (routesData && routesData.length === 0) {
             return <NoRouteFound />;}
         else if (routesData) {
-            return ( // AREA OF INTEREST
+            return (
                 <>
-                    <Box sx={{ display: 'flex', justifyContent: 'center',gap: 5, margin: 2}}>
-                        <Button variant="contained" color="primary" onClick={checkAllRoutes}>
-                            Check All Routes
-                        </Button>
-                        <Button variant="contained" color="secondary" onClick={uncheckAllRoutes}>
-                            Uncheck All Routes
-                        </Button>
-                    </Box>
                 <Table>
                     <TableHead>
                         <TableRow>
@@ -219,8 +223,8 @@ const LiveTracking = () => {
                                             fontSize: 28, // Adjust the size of the checkbox icon
                                         },
                                     }}
-                                    defaultChecked
-                                    checked={checkAllRoutes} // Control the checkbox state 
+                                    checked={selectAll}
+                                    onChange={handleSelectAllChange} // Call the new function
                                 />    
                             </TableCell>
                             <TableCell>Route ID</TableCell>
@@ -357,6 +361,14 @@ const LiveTracking = () => {
             setCheckedRoutes(initialCheckedRoutes);
         }
     }, [routesData]);
+
+    // update selectAll state based on checkedRoutes
+    useEffect(() => {
+        if (routesData) {
+            const allChecked = routesData.every(route => !!checkedRoutes[route.deliveryRouteID]);
+            setSelectAll(allChecked);
+        }
+    }, [checkedRoutes, routesData]);
 
 
     return (


### PR DESCRIPTION
- Removed old buttons for checking all routes
- Added toggle all checkbox on top row
  - Added handling such that it is automatically updated if you don't use the toggle all button
  
- Takes the default colour
- Takes the same size as other checkboxes on the page